### PR TITLE
Revert "Bump version to 1.0.0", bump to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ristretto255-dh"
-version = "1.0.0"
+version = "0.2.0"
 authors = ["Deirdre Connolly <durumcrustulum@gmail.com>"]
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
This reverts commit b6dd31165f71ab213f976787ca842a46317fa5c9.

semver 0.* is unstable, don't have to bump to 1.0.0 for a breaking
change, yet.